### PR TITLE
Feat : 진료예약 알림 기능 추가 #24

### DIFF
--- a/backend/src/main/java/com/petner/anidoc/domain/notice/service/NoticeService.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/notice/service/NoticeService.java
@@ -48,6 +48,7 @@ public class NoticeService {
                     .content(notificationService.getSummary(saved.getContent()))
                     .writerName(user.getName())
                     .createdAt(saved.getCreatedAt())
+                    .isRead(false)
                     .build();
 
             notificationService.notifyUser(
@@ -79,6 +80,7 @@ public class NoticeService {
                 .content(notificationService.getSummary(notice.getContent()))
                 .writerName(user.getName())
                 .createdAt(notice.getCreatedAt())
+                .isRead(false)
                 .build();
         // 이벤트명 추가(선택), 프론트에 push
         notificationService.notifyAll(

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/controller/NotificationSseController.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/controller/NotificationSseController.java
@@ -53,68 +53,8 @@ public class NotificationSseController {
         return ResponseEntity.ok(emitter);
     }
 
-    //테스트 코드
-    //예방접종 알림 테스트
-    @PostMapping("/vaccination")
-    @Operation(summary = "예방접종 알림 테스트", description = "dto 사용해 전송")
-    public void vaccination(
-            @RequestParam Long userId){
-        VaccinationNotificationDto dto = VaccinationNotificationDto.builder()
-                .vaccinationId(1L)
-                .petId(101L)
-                .petName("냥냥")
-                .vaccineName("감기약")
-                .nextDueDate("2025-05-13 17:00")
-                .vaccinationDate("2025-05-13 19:00")
-                .build();
 
-        notificationService.notifyUser(
-                userId,
-                NotificationType.VACCINATION,
-                "두번째 예방접종 알림 테스트 입니다.",
-                dto
-        );
 
     }
 
 
-    //공지사항 알림(전체) 테스트
-
-    @PostMapping("/test/notice")
-    @Operation(summary = "공지사항 전체 알림 테스트", description = "dto 사용해 전송")
-    public void testNotice() {
-        NoticeNotificationDto dto = NoticeNotificationDto.builder()
-                .noticeId(100L)
-                .title("시스템 점검 안내")
-                .writerName("관리자")
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        notificationService.notifyAll(
-                NotificationType.NOTICE,
-                "두번째 최종 전체 공지사항 알림입니다.",
-                dto
-        );
-    }
-
-    @PostMapping("/test/reservation")
-    @Operation(summary = "개인 진료예약 알림 테스트", description = "dto 사용해 전송")
-    public void testReservation(@RequestParam Long userId) {
-        ReservationNotificationDto dto = new ReservationNotificationDto(
-                200L,
-                "홍길동",
-                "초코",
-                "2024-07-01 10:00",
-                "2024-06-15 09:00",
-                "AniDoc"
-        );
-
-        notificationService.notifyUser(
-                userId,
-                NotificationType.RESERVATION,
-                "두번째 진료 예약 알림입니다.",
-                dto
-        );
-    }
-
-}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/NoticeNotificationDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/NoticeNotificationDto.java
@@ -16,5 +16,6 @@ public class NoticeNotificationDto {
     private String content;
     private String writerName;
     private LocalDateTime createdAt;
+    private Boolean isRead;
 
 }

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/ReservationNotificationDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/ReservationNotificationDto.java
@@ -1,9 +1,15 @@
 package com.petner.anidoc.domain.user.notification.dto;
 
+import com.petner.anidoc.domain.vet.reservation.entity.Reservation;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 @Data
 @NoArgsConstructor
@@ -14,8 +20,26 @@ public class ReservationNotificationDto {
     private Long reservationId;
     private String userName;
     private String petName;
-    private String dateTime;
-    private String createdAt;
-    private String hospitalName;
+    private LocalDate reservationDate;
+    private LocalTime reservationTime;
+    private String status;
+    private LocalDateTime createdAt; // 알림 생성일시
+    private Boolean isRead;
+    private String content;
+
+    public static ReservationNotificationDto from(Reservation reservation) {
+
+        return ReservationNotificationDto.builder()
+                .reservationId(reservation.getId())
+                .userName(reservation.getUser().getName())
+                .petName(reservation.getPet().getName())
+                .reservationDate(reservation.getReservationDate())
+                .reservationTime(reservation.getReservationTime())
+                .status(reservation.getStatus().name())
+                .createdAt(reservation.getCreatedAt())
+                .isRead(false)
+                .build();
+
+    }
 
 }

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/NotificationMessageUtil.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/NotificationMessageUtil.java
@@ -1,0 +1,66 @@
+package com.petner.anidoc.domain.user.notification.util;
+
+import com.petner.anidoc.domain.user.notification.dto.ReservationNotificationDto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class NotificationMessageUtil {
+
+    //예약 날짜 포맷
+    public static String getFormattedReservationDateTime(LocalDate reservationDate, LocalTime reservationTime) {
+        if(reservationDate == null || reservationTime == null) return "";
+        //날짜 형식
+        LocalDateTime dateTime = LocalDateTime.of(reservationDate, reservationTime);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy년 M월 d일 HH시 mm분");
+        return dateTime.format(formatter);
+    }
+
+    // 예약 생성 메시지
+    public static String buildReservationCreated(ReservationNotificationDto dto) {
+        return String.format("%s님의 %s 진료예약이 등록되었습니다. 예약일시: %s",
+                dto.getUserName(),
+                dto.getPetName(),
+                getFormattedReservationDateTime(dto.getReservationDate(), dto.getReservationTime())
+        );
+    }
+
+    //예약 확정 메시지
+    public static String buildReservationStatusApproved(ReservationNotificationDto dto){
+        return String.format("%s님의 %s 진료예약이 확정되었습니다. 예약일시: %s",
+            dto.getUserName(),
+            dto.getPetName(),
+            getFormattedReservationDateTime(dto.getReservationDate(), dto.getReservationTime())
+        );
+    }
+
+    //예약 거절 메시지
+    public static String buildReservationStatusRejected(ReservationNotificationDto dto){
+        return String.format("%s님의 %s 진료예약이 거절되었습니다. 예약일시: %s",
+                dto.getUserName(),
+                dto.getPetName(),
+                getFormattedReservationDateTime(dto.getReservationDate(), dto.getReservationTime())
+        );
+    }
+
+    //예약 취소 메시지
+    public static String buildReservationCancelled(ReservationNotificationDto dto){
+        return String.format("%s님의 %s 진료예약이 취소되었습니다. 예약일시: %s",
+                dto.getUserName(),
+                dto.getPetName(),
+                getFormattedReservationDateTime(dto.getReservationDate(), dto.getReservationTime())
+        );
+    }
+
+    //예약 수정 메시지
+    public static String buildReservationUpdated(ReservationNotificationDto dto){
+        return String.format("%s님의 %s 진료예약이 변경되었습니다. 예약일시: %s",
+                dto.getUserName(),
+                dto.getPetName(),
+                getFormattedReservationDateTime(dto.getReservationDate(), dto.getReservationTime())
+        );
+    }
+
+}


### PR DESCRIPTION

# 🧠 Feature PR


### 1️⃣관련 이슈

🔗#24
</br></br>

### 2️⃣작업 내용

✒️예약 알림 기능 추가 
✒️messageUtil 추가
✒️공지사항 일부 기능 추가(읽음 표시)
</br></br>


### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [ x] 로컬에서 테스트 완료 🧪🫧

</br>어떻게 테스트했는지 (경로, 사용 조건 등)

✒️ Swagger, h2
✒️ (유저) 펫등록 -> 진료 예약 
✒️ (관리자) 담당의 배정 -> 진료 확정 -> 예약 수정 -> 예약 삭제
✒️ h2 Notification 테이블 확인
</br></br>
### 4️⃣이슈 넘버 기술
Closes #24 


