### PR TITLE
[REFACTOR] 기간별 채팅 내역 조회

### DIFF
--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/controller/ChatController.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/controller/ChatController.java
@@ -12,13 +12,14 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
+@MessageMapping("/chat")
 public class ChatController {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatMessageService chatMessageService;
 
     // 프론트엔드에서 /pub/chat/message 로 메시지를 보내면 처리
-    @MessageMapping("/chat/message")
+    @MessageMapping("/message")
     public void sendMessage(@Payload ChatMessageRequestDto messageDto) {
         // 메시지 저장
         ChatMessageResponseDto savedMessage = chatMessageService.saveMessage(messageDto);
@@ -28,7 +29,7 @@ public class ChatController {
     }
 
     // 읽음 처리
-    @MessageMapping("/chat/read")
+    @MessageMapping("/read")
     public void markAsRead(@Payload ReadStatusDto readStatusDto) {
         chatMessageService.markMessagesAsRead(readStatusDto.getRoomId(), readStatusDto.getUserId());
 

--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/dto/ChatMessagePageResponseDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/dto/ChatMessagePageResponseDto.java
@@ -1,0 +1,21 @@
+package com.petner.anidoc.domain.chat.chatmessage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChatMessagePageResponseDto {
+    private List<ChatMessageResponseDto> messages;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/repository/ChatMessageRepository.java
@@ -2,6 +2,8 @@ package com.petner.anidoc.domain.chat.chatmessage.repository;
 
 import com.petner.anidoc.domain.chat.chatmessage.entity.ChatMessage;
 import com.petner.anidoc.domain.chat.chatroom.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +18,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :roomId AND cm.isRead = false AND cm.sender.id != :userId")
     List<ChatMessage> findUnreadMessagesByRoomAndUser(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
+    // 최신 메시지부터 페이지로 조회
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :roomId ORDER BY cm.createdAt DESC")
+    Page<ChatMessage> findByChatRoomIdOrderByCreatedAtDesc(@Param("roomId") Long roomId, Pageable pageable);
+
+    // 특정 메시지 ID 이후의 메시지들 조회
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :roomId AND cm.id < :lastMessageId ORDER BY cm.createdAt DESC")
+    Page<ChatMessage> findByChatRoomIdAndIdLessThanOrderByCreatedAtDesc(
+            @Param("roomId") Long roomId,
+            @Param("lastMessageId") Long lastMessageId,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/service/ChatMessageService.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ChatMessageService {
 
-    private static final int DEFAULT_PAGE_SIZE = 30; // 한 페이지당 메시지 수
+    private static final int DEFAULT_PAGE_SIZE = 20; // 한 페이지당 메시지 수
 
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;

--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/service/ChatMessageService.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatmessage/service/ChatMessageService.java
@@ -1,5 +1,6 @@
 package com.petner.anidoc.domain.chat.chatmessage.service;
 
+import com.petner.anidoc.domain.chat.chatmessage.dto.ChatMessagePageResponseDto;
 import com.petner.anidoc.domain.chat.chatmessage.dto.ChatMessageRequestDto;
 import com.petner.anidoc.domain.chat.chatmessage.dto.ChatMessageResponseDto;
 import com.petner.anidoc.domain.chat.chatmessage.entity.ChatMessage;
@@ -8,7 +9,12 @@ import com.petner.anidoc.domain.chat.chatroom.entity.ChatRoom;
 import com.petner.anidoc.domain.chat.chatroom.repository.ChatRoomRepository;
 import com.petner.anidoc.domain.user.user.entity.User;
 import com.petner.anidoc.domain.user.user.repository.UserRepository;
+import com.petner.anidoc.global.exception.CustomException;
+import com.petner.anidoc.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +25,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ChatMessageService {
+
+    private static final int DEFAULT_PAGE_SIZE = 30; // 한 페이지당 메시지 수
 
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
@@ -55,6 +63,56 @@ public class ChatMessageService {
         return messages.stream()
                 .map(ChatMessageResponseDto::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    // 최신 메시지 페이지 조회 (첫 로드)
+    public ChatMessagePageResponseDto getLatestChatMessages(Long roomId, int page) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, DEFAULT_PAGE_SIZE);
+        Page<ChatMessage> messagePage = chatMessageRepository.findByChatRoomIdOrderByCreatedAtDesc(roomId, pageable);
+
+        // 최신순으로 조회했으니 순서 뒤집어야 함 (프론트엔드 표시용)
+        List<ChatMessageResponseDto> messages = messagePage.getContent()
+                .stream()
+                .sorted((m1, m2) -> m1.getCreatedAt().compareTo(m2.getCreatedAt()))
+                .map(ChatMessageResponseDto::fromEntity)
+                .collect(Collectors.toList());
+
+        return ChatMessagePageResponseDto.builder()
+                .messages(messages)
+                .totalElements(messagePage.getTotalElements())
+                .totalPages(messagePage.getTotalPages())
+                .currentPage(page)
+                .hasNext(messagePage.hasNext())
+                .hasPrevious(messagePage.hasPrevious())
+                .build();
+    }
+
+    public ChatMessagePageResponseDto getPreviousChatMessages(Long roomId, Long lastMessageId, int page) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, DEFAULT_PAGE_SIZE);
+        Page<ChatMessage> messagePage = chatMessageRepository
+                .findByChatRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, lastMessageId, pageable);
+
+        // 최신순으로 조회했으니 순서 뒤집어야 함 (프론트엔드 표시용)
+        List<ChatMessageResponseDto> messages = messagePage.getContent()
+                .stream()
+                .sorted((m1, m2) -> m1.getCreatedAt().compareTo(m2.getCreatedAt()))
+                .map(ChatMessageResponseDto::fromEntity)
+                .collect(Collectors.toList());
+
+        return ChatMessagePageResponseDto.builder()
+                .messages(messages)
+                .totalElements(messagePage.getTotalElements())
+                .totalPages(messagePage.getTotalPages())
+                .currentPage(page)
+                .hasNext(messagePage.hasNext())
+                .hasPrevious(messagePage.hasPrevious())
+                .build();
     }
 
     // 메시지 읽음 처리

--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatroom/controller/ChatRoomController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/chat")
+@RequestMapping("/api/chat/rooms")
 @Tag(name = "채팅", description = "Chat 관련 API")
 public class ChatRoomController {
 
@@ -25,19 +25,19 @@ public class ChatRoomController {
     private final ChatMessageService chatMessageService;
 
     @Operation(summary = "채팅방 생성/조회", description = "예약 ID로 채팅방을 생성하거나 이미 존재하면 조회합니다.")
-    @PostMapping("/rooms")
+    @PostMapping
     public ResponseEntity<ChatRoomResponseDto> createOrGetChatRoom(@RequestBody ChatRoomRequestDto requestDto) {
         return new ResponseEntity<>(chatRoomService.createOrGetChatRoom(requestDto), HttpStatus.CREATED);
     }
 
     @Operation(summary = "유저 채팅방 목록 조회", description = "유저 ID로 채팅방 목록을 조회합니다.")
-    @GetMapping("/rooms/user/{userId}")
+    @GetMapping("/user/{userId}")
     public ResponseEntity<List<ChatRoomResponseDto>> getUserChatRooms(@PathVariable Long userId) {
         return ResponseEntity.ok(chatRoomService.getUserChatRooms(userId));
     }
 
     @Operation(summary = "채팅방 상세 조회", description = "채팅방 ID로 채팅방 상세 정보를 조회합니다.")
-    @GetMapping("/rooms/{roomId}")
+    @GetMapping("/{roomId}")
     public ResponseEntity<ChatRoomResponseDto> getChatRoom(
             @PathVariable Long roomId,
             @RequestParam Long userId) {
@@ -45,13 +45,13 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "채팅방 메시지 목록 조회", description = "채팅방 ID로 메시지 목록을 조회합니다.")
-    @GetMapping("/rooms/{roomId}/messages")
+    @GetMapping("/{roomId}/messages")
     public ResponseEntity<List<ChatMessageResponseDto>> getChatMessages(@PathVariable Long roomId) {
         return ResponseEntity.ok(chatMessageService.getChatMessages(roomId));
     }
 
     @Operation(summary = "채팅방 메시지 페이지 조회", description = "채팅방 ID로 메시지를 페이지로 조회합니다.")
-    @GetMapping("/rooms/{roomId}/messages/page")
+    @GetMapping("/{roomId}/messages/page")
     public ResponseEntity<ChatMessagePageResponseDto> getChatMessagesPage(
             @PathVariable Long roomId,
             @RequestParam(defaultValue = "0") int page) {
@@ -59,7 +59,7 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "이전 메시지 페이지 조회", description = "특정 메시지 이전의 메시지들을 조회합니다.")
-    @GetMapping("/rooms/{roomId}/messages/prev")
+    @GetMapping("/{roomId}/messages/prev")
     public ResponseEntity<ChatMessagePageResponseDto> getPreviousMessages(
             @PathVariable Long roomId,
             @RequestParam Long lastMessageId,
@@ -68,7 +68,7 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "메시지 읽음 처리", description = "채팅방의 메시지를 읽음 처리합니다.")
-    @PostMapping("/rooms/{roomId}/read")
+    @PostMapping("/{roomId}/read")
     public ResponseEntity<Void> markMessagesAsRead(
             @PathVariable Long roomId,
             @RequestParam Long userId) {

--- a/backend/src/main/java/com/petner/anidoc/domain/chat/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/chat/chatroom/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.petner.anidoc.domain.chat.chatroom.controller;
 
+import com.petner.anidoc.domain.chat.chatmessage.dto.ChatMessagePageResponseDto;
 import com.petner.anidoc.domain.chat.chatmessage.dto.ChatMessageResponseDto;
 import com.petner.anidoc.domain.chat.chatmessage.service.ChatMessageService;
 import com.petner.anidoc.domain.chat.chatroom.dto.ChatRoomRequestDto;
@@ -47,6 +48,23 @@ public class ChatRoomController {
     @GetMapping("/rooms/{roomId}/messages")
     public ResponseEntity<List<ChatMessageResponseDto>> getChatMessages(@PathVariable Long roomId) {
         return ResponseEntity.ok(chatMessageService.getChatMessages(roomId));
+    }
+
+    @Operation(summary = "채팅방 메시지 페이지 조회", description = "채팅방 ID로 메시지를 페이지로 조회합니다.")
+    @GetMapping("/rooms/{roomId}/messages/page")
+    public ResponseEntity<ChatMessagePageResponseDto> getChatMessagesPage(
+            @PathVariable Long roomId,
+            @RequestParam(defaultValue = "0") int page) {
+        return ResponseEntity.ok(chatMessageService.getLatestChatMessages(roomId, page));
+    }
+
+    @Operation(summary = "이전 메시지 페이지 조회", description = "특정 메시지 이전의 메시지들을 조회합니다.")
+    @GetMapping("/rooms/{roomId}/messages/prev")
+    public ResponseEntity<ChatMessagePageResponseDto> getPreviousMessages(
+            @PathVariable Long roomId,
+            @RequestParam Long lastMessageId,
+            @RequestParam(defaultValue = "0") int page) {
+        return ResponseEntity.ok(chatMessageService.getPreviousChatMessages(roomId, lastMessageId, page));
     }
 
     @Operation(summary = "메시지 읽음 처리", description = "채팅방의 메시지를 읽음 처리합니다.")

--- a/backend/src/main/java/com/petner/anidoc/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/petner/anidoc/global/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
     LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,  "로그아웃에 실패했습니다."),
 
     // 병원 정보 관련 오류
-    VET_NOT_FOUND(HttpStatus.NOT_FOUND,"병원이 존재하지 않습니다.");
+    VET_NOT_FOUND(HttpStatus.NOT_FOUND,"병원이 존재하지 않습니다."),
+
+    // 채팅 관련 오류
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다.");
 
     // HTTP 상태 코드와 메시지
     private final HttpStatus httpStatus;

--- a/frontend/src/app/reservation/[id]/page.tsx
+++ b/frontend/src/app/reservation/[id]/page.tsx
@@ -178,9 +178,6 @@ export default function ReservationDetailPage() {
               <ul className="list-disc list-inside space-y-2 text-gray-700">
                 <li>예약 시간 10분 전에 도착해주세요.</li>
                 <li>반려동물 건강기록부가 있다면 지참해주세요.</li>
-                <li>
-                  최근 식사 및 배변 상태를 메모해오시면 진료에 도움이 됩니다.
-                </li>
                 <li>필요시 이전 병원 진료기록을 지참해주세요.</li>
               </ul>
             </div>

--- a/frontend/src/components/chat/ChatRoom.tsx
+++ b/frontend/src/components/chat/ChatRoom.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import ChatMessage from "./ChatMessage";
 import ChatInput from "./ChatInput";
 import { useUser } from "@/contexts/UserContext";
@@ -13,7 +13,11 @@ interface ChatRoomProps {
 export default function ChatRoom({ reservationId }: ChatRoomProps) {
   const { user } = useUser();
   const [roomId, setRoomId] = useState<number | null>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const loadingTriggerRef = useRef<HTMLDivElement>(null);
+  const [isAutoScroll, setIsAutoScroll] = useState(true);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   // 채팅방 정보 가져오기
   useEffect(() => {
@@ -50,41 +54,151 @@ export default function ChatRoom({ reservationId }: ChatRoomProps) {
     createOrGetChatRoom();
   }, [reservationId, user]);
 
-  const { messages, connected, sendMessage } = useWebSocket({
+  const {
+    messages,
+    connected,
+    loading,
+    hasMoreMessages,
+    sendMessage,
+    loadMoreMessages,
+  } = useWebSocket({
     roomId,
     userId: user?.id || null,
   });
 
-  // 스크롤 처리
+  // 초기 메시지 로드하고 맨 아래로 스크롤
   useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
+    if (isInitialLoad && messages.length > 0) {
+      requestAnimationFrame(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+        setIsInitialLoad(false);
+      });
+    }
+  }, [messages, isInitialLoad]);
+
+  // 새 메시지가 추가될 때 자동 스크롤
+  useEffect(() => {
+    if (!isInitialLoad && isAutoScroll && messages.length > 0) {
+      scrollToBottom();
+    }
+  }, [messages, isAutoScroll, isInitialLoad]);
+
+  // 무한스크롤 감지
+  useEffect(() => {
+    // 초기 로드 중이거나 더 불러올 메시지가 없으면 옵저버 비활성화
+    if (isInitialLoad || !hasMoreMessages) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && !loading) {
+          console.log("무한스크롤 트리거됨");
+          loadMoreMessages();
+        }
+      },
+      {
+        root: messagesContainerRef.current,
+        rootMargin: "50px 0px 0px 0px",
+        threshold: 0.1,
+      }
+    );
+
+    if (loadingTriggerRef.current) {
+      observer.observe(loadingTriggerRef.current);
+    }
+
+    return () => {
+      if (loadingTriggerRef.current) {
+        observer.unobserve(loadingTriggerRef.current);
+      }
+    };
+  }, [isInitialLoad, hasMoreMessages, loading]);
+
+  // 스크롤 위치 감지해서 자동 스크롤 여부 결정
+  const handleScroll = useCallback(() => {
+    if (isInitialLoad) return; // 초기 로드 중에는 스크롤 감지 비활성화
+
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 300;
+    setIsAutoScroll(isAtBottom);
+  }, [isInitialLoad]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   if (!roomId || !user) {
-    return <div className="p-4 text-center">로딩 중...</div>;
+    return (
+      <div className="flex justify-center items-center h-full">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500"></div>
+      </div>
+    );
   }
 
   return (
-    <div className="flex flex-col h-full rounded-lg overflow-hidden shadow-sm bg-white">
+    <div className="flex flex-col h-full rounded-lg overflow-hidden shadow-sm bg-white relative">
       <div className="bg-teal-50 p-3 border-b border-teal-100">
         <h2 className="font-semibold text-teal-700">1:1 상담</h2>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
-        {messages.map((message) => (
-          <ChatMessage
-            key={message.id}
-            message={message}
-            isOwnMessage={message.senderId === user.id}
-          />
-        ))}
+      <div
+        ref={messagesContainerRef}
+        className="flex-1 overflow-y-auto p-4 relative"
+        onScroll={handleScroll}
+      >
+        {/* 이전 메시지 로딩 영역 */}
+        {!isInitialLoad && hasMoreMessages && (
+          <div ref={loadingTriggerRef} className="text-center py-2">
+            {loading ? (
+              <div className="flex justify-center">
+                <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-teal-500"></div>
+              </div>
+            ) : (
+              <div className="text-gray-400 text-sm">이전 메시지 불러오기</div>
+            )}
+          </div>
+        )}
+
+        {/* 메시지 목록 */}
+        <div className="space-y-3">
+          {messages.map((message) => (
+            <ChatMessage
+              key={message.id}
+              message={message}
+              isOwnMessage={message.senderId === user.id}
+            />
+          ))}
+        </div>
         <div ref={messagesEndRef} />
       </div>
 
+      {/* 맨 아래로 스크롤 버튼 */}
+      {!isAutoScroll && !isInitialLoad && (
+        <div className="absolute bottom-20 right-4 z-10">
+          <button
+            onClick={scrollToBottom}
+            className="bg-white border border-gray-300 text-gray-600 w-10 h-10 rounded-full shadow-lg hover:bg-gray-50 hover:shadow-xl transition-all duration-200 flex items-center justify-center"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M6 9l6 6 6-6"></path>
+            </svg>
+          </button>
+        </div>
+      )}
       <ChatInput onSendMessage={sendMessage} disabled={!connected} />
     </div>
   );


### PR DESCRIPTION
# 🔄 Refactor PR

### 1️⃣관련 이슈
🔗#56
</br></br>

### 2️⃣리팩토링 범위
✒️채팅 내역 조회를 기간별로 불러오도록 수정 - 커서 기반 페이지네이션
✒️채팅창 무한스크롤 구현
</br></br>

### 3️⃣이유
✒️채팅을 한 번에 불러오면 성능 문제가 있을 수 있으니, 커서 기반 페이지네이션 형식으로 변경
</br></br>

### 4️⃣이슈 넘버 기술
Closes #56

