### PR TITLE
[FEAT] 통계 기능 백엔드 구현

### DIFF
--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/controller/StatisticsController.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/controller/StatisticsController.java
@@ -1,0 +1,56 @@
+package com.petner.anidoc.domain.statistics.controller;
+
+import com.petner.anidoc.domain.statistics.dto.*;
+import com.petner.anidoc.domain.statistics.service.StatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/statistics")
+@RequiredArgsConstructor
+@Tag(name = "통계", description = "통계 관련 API")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    //지난 주 방문자 통계
+    @Operation(summary = "지난 주 방문자 통계")
+    @GetMapping("/weekly")
+    public WeeklyStatisticsDto getLastWeekStatistics(){
+        return statisticsService.getLastWeekWeekStatistics();
+    }
+
+    //지난 달 방문자 통계
+    @Operation(summary = "지난 달 방문자 통계")
+    @GetMapping("/monthly")
+    public MonthlyStatisticsDto getLastMonthStatistics(){
+        return statisticsService.getLastMonthWeekStatistics();
+    }
+
+    //지난 주 - 이번 주 방문자 비교
+    @Operation(summary = "주간 방문자 비교")
+    @GetMapping("/weekly-comparison")
+    public WeeklyComparisonDto getWeeklyComparison(){
+        return statisticsService.getWeeklyComparison();
+    }
+
+    //지난 달 - 이번 달 방문자 비교
+    @Operation(summary = "월간 방문자 비교")
+    @GetMapping("/monthly-comparison")
+    public MonthlyComparisonDto getMonthlyComparison(){
+        return statisticsService.getMonthlyComparison();
+    }
+
+
+    //지난 달 동물 별 비율
+    @Operation(summary = "지난 달 동물별 진료 비율 통계")
+    @GetMapping("/monthly-animal-rate")
+    public AnimalTypeDto getLastMonthAnimalRate(){
+        return  statisticsService.getLastMonthAnimalTypeRate();
+    }
+
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/AnimalTypeDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/AnimalTypeDto.java
@@ -1,0 +1,16 @@
+package com.petner.anidoc.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnimalTypeDto {
+    private String period;
+    private Long dogCount;
+    private Long catCount;
+    private Long otherCount;
+    private Long totalCount;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/MonthlyComparisonDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/MonthlyComparisonDto.java
@@ -1,0 +1,19 @@
+package com.petner.anidoc.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthlyComparisonDto {
+    private String lastMonthPeriod;
+    private Long lastMonthVisitCount;
+
+    private String thisMonthPeriod;
+    private Long thisMonthVisitCount;
+
+    private String trend;
+    private String changeRate;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/MonthlyStatisticsDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/MonthlyStatisticsDto.java
@@ -1,0 +1,13 @@
+package com.petner.anidoc.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthlyStatisticsDto {
+    private String period;
+    private Long visitCount;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/TreatmentTypeDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/TreatmentTypeDto.java
@@ -1,0 +1,15 @@
+package com.petner.anidoc.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TreatmentTypeDto {
+    private String period;
+    private Long generalCount; // 일반진료 개수
+    private Long vaccinationCount; // 예방접종 개수
+    private Long totalCount;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/WeeklyComparisonDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/WeeklyComparisonDto.java
@@ -1,0 +1,19 @@
+package com.petner.anidoc.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeeklyComparisonDto {
+    private String LastWeekPeriod;
+    private Long LastWeekVisitCount;
+
+    private String thisWeekPeriod;
+    private Long thisWeekVisitCount;
+
+    private String trend;
+    private String changeRate;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/WeeklyStatisticsDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/dto/WeeklyStatisticsDto.java
@@ -1,0 +1,13 @@
+package com.petner.anidoc.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeeklyStatisticsDto {
+    private String period;
+    private Long visitCount;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/repository/StatisticsRepository.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/repository/StatisticsRepository.java
@@ -1,0 +1,72 @@
+package com.petner.anidoc.domain.statistics.repository;
+
+import com.petner.anidoc.domain.vet.medicalrecord.entity.MedicalRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface StatisticsRepository extends JpaRepository<MedicalRecord, Long> {
+
+    //전주 방문 건수
+    @Query("SELECT COUNT(m) FROM MedicalRecord m "
+            +"WHERE m.createdAt >= :startDate And m.createdAt < :endDate")
+    Long countLastWeekVisits(@Param("startDate")LocalDateTime startDate,
+                             @Param("endDate")LocalDateTime endDate);
+
+    //이번 주 방문 건수
+    @Query("SELECT COUNT(m) FROM MedicalRecord m "
+            +"WHERE m.createdAt >= :startDate And m.createdAt <= :endDate")
+    Long countThisWeekVisits(@Param("startDate")LocalDateTime startDate,
+                             @Param("endDate")LocalDateTime endDate);
+
+    //전월 방문 건수
+    @Query("SELECT COUNT(m) FROM MedicalRecord m"
+    + " WHERE m.createdAt >= :startDate AND m.createdAt < :endDate")
+    Long countLastMonthVisits(@Param("startDate")LocalDateTime startDate,
+                              @Param("endDate")LocalDateTime endDate);
+
+
+    //이번 달 방문 건수
+    @Query("SELECT COUNT(m) FROM MedicalRecord m"
+            + " WHERE m.createdAt >= :startDate AND m.createdAt <= :endDate")
+    Long countThisMonthVisits(@Param("startDate")LocalDateTime startDate,
+                              @Param("endDate")LocalDateTime endDate);
+
+
+    //예방접종 건수
+    @Query("SELECT COUNT(m) FROM MedicalRecord m"
+            + " WHERE m.createdAt >= :startDate AND m.createdAt < :endDate"
+            + " AND (m.diagnosis LIKE '%예방접종%' OR m.diagnosis LIKE '%접종%' OR m.diagnosis LIKE '%백신%')" )
+    Long countVaccinated(@Param("startDate")LocalDateTime startDate,
+                              @Param("endDate")LocalDateTime endDate);
+
+
+    //강아지 진료 건수(전체 진료)
+    @Query("SELECT COUNT(m) FROM MedicalRecord  m " +
+            " WHERE m.createdAt >= :startDate AND m.createdAt < :endDate" +
+            " AND m.pet.species = '강아지'")
+    Long countDogTreatments(@Param("startDate")LocalDateTime startDate,
+                              @Param("endDate")LocalDateTime endDate);
+
+
+    //고양이 진료 건수(전체 진료)
+    @Query("SELECT COUNT(m) FROM MedicalRecord  m " +
+            " WHERE m.createdAt >= :startDate AND m.createdAt < :endDate" +
+            " AND m.pet.species = '고양이'")
+    Long countCatTreatments(@Param("startDate")LocalDateTime startDate,
+                              @Param("endDate")LocalDateTime endDate);
+
+
+    //기타 동물 진료 건수(전체 진료)
+    @Query("SELECT COUNT(m) FROM MedicalRecord  m " +
+            " WHERE m.createdAt >= :startDate AND m.createdAt < :endDate" +
+            " AND m.pet.species NOT IN ('강아지', '고양이') ")
+    Long countOtherTreatments(@Param("startDate")LocalDateTime startDate,
+                              @Param("endDate")LocalDateTime endDate);
+
+}
+

--- a/backend/src/main/java/com/petner/anidoc/domain/statistics/service/StatisticsService.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/statistics/service/StatisticsService.java
@@ -1,0 +1,134 @@
+package com.petner.anidoc.domain.statistics.service;
+
+import com.petner.anidoc.domain.statistics.dto.*;
+import com.petner.anidoc.domain.statistics.repository.StatisticsRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private final StatisticsRepository statisticsRepository;
+
+    //전주 방문자 통계
+    @Transactional
+    public WeeklyStatisticsDto getLastWeekWeekStatistics(){
+        LocalDateTime now = LocalDateTime.now();
+
+        //이번 주 월요일 0시
+        LocalDateTime end = now.minusDays(now.getDayOfWeek().getValue() - 1)
+                .withHour(0).withMinute(0).withSecond(0);
+
+        //지난 주 월요일 0시
+        LocalDateTime start = end.minusWeeks(1);
+
+        Long visitCount = statisticsRepository.countLastWeekVisits(start, end);
+
+        String period ="지난 주: " + start.format(DateTimeFormatter.ofPattern("MM월 dd일"))
+                + " ~ " + end.format(DateTimeFormatter.ofPattern("MM월 dd일"));
+
+        return new WeeklyStatisticsDto(period, visitCount);
+    }
+
+    //전월 방문자 통계
+    @Transactional
+    public MonthlyStatisticsDto getLastMonthWeekStatistics(){
+        LocalDateTime now = LocalDateTime.now();
+
+        //이번 달 1일 0시 0분
+        LocalDateTime end = now.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+
+        //지난 달 1일 0시 0분
+        LocalDateTime start = end.minusMonths(1);
+
+        Long visitCount = statisticsRepository.countLastMonthVisits(start, end);
+
+        String period = start.format(DateTimeFormatter.ofPattern("yyyy년 MM월"));
+
+        return new MonthlyStatisticsDto(period, visitCount);
+
+    }
+
+    //전주 방문자 비교
+    @Transactional
+    public WeeklyComparisonDto getWeeklyComparison(){
+        WeeklyStatisticsDto lastWeek = getLastWeekWeekStatistics();
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start = now.minusDays(now.getDayOfWeek().getValue() - 1)
+                .withHour(0).withMinute(0).withSecond(0);
+        Long thisWeekVisitCount = statisticsRepository.countLastWeekVisits(start, now);
+
+        String thisWeekPeriod = "이번 주: "+ start.format(DateTimeFormatter.ofPattern("MM월 dd일"))
+                +" ~ " + now.format(DateTimeFormatter.ofPattern("MM월 dd일"));
+
+        String trend = calculateTrend(lastWeek.getVisitCount(), thisWeekVisitCount);
+        String changeRate = calculateChangeRate(lastWeek.getVisitCount(), thisWeekVisitCount);
+
+        return new WeeklyComparisonDto(lastWeek.getPeriod(), lastWeek.getVisitCount(), thisWeekPeriod, thisWeekVisitCount, trend, changeRate);
+    }
+
+
+    //전월 방문자 비교
+    @Transactional
+    public MonthlyComparisonDto getMonthlyComparison(){
+        MonthlyStatisticsDto lastMonth = getLastMonthWeekStatistics();
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start = now.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+
+        Long thisMonthVisitCount = statisticsRepository.countLastMonthVisits(start, now);
+
+        String thisMonthPeriod = start.format(DateTimeFormatter.ofPattern("yyyy년 MM월"));
+
+        String trend = calculateTrend(lastMonth.getVisitCount(), thisMonthVisitCount);
+        String changeRate = calculateChangeRate(lastMonth.getVisitCount(), thisMonthVisitCount);
+
+        return new MonthlyComparisonDto(lastMonth.getPeriod(), lastMonth.getVisitCount(), thisMonthPeriod, thisMonthVisitCount, trend, changeRate);
+    }
+
+    //지난 달 강아지/고양이/기타 전체 진료 기준 비율 통계
+    @Transactional
+    public AnimalTypeDto getLastMonthAnimalTypeRate(){
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime end = now.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime start = end.minusMonths(1);
+
+        Long dogCount = statisticsRepository.countDogTreatments(start, end);
+        Long catCount = statisticsRepository.countCatTreatments(start, end);
+        Long otherCount = statisticsRepository.countOtherTreatments(start, end);
+        Long totalCount = dogCount + catCount + otherCount;
+
+        String period = start.format(DateTimeFormatter.ofPattern("yyyy년 MM월"));
+
+        return new AnimalTypeDto(period, dogCount, catCount, otherCount, totalCount);
+    }
+
+
+    //비교 로직
+    private String calculateTrend(Long previous , Long current){
+        if(current > previous){
+            return "증가";
+        }else  if(current <previous){
+            return "감소";
+        } else {return " 동일";}
+    }
+
+    private String calculateChangeRate(Long previous , Long current){
+      if(previous == 0){
+          return current > 0 ? "+100%" : "0%";
+      }
+
+      double rate = ((double) (current - previous) /previous) * 100;
+      return String.format("%.0f%%", rate);
+
+    }
+
+
+}


### PR DESCRIPTION

# 🧠 Feature PR


### 1️⃣관련 이슈

🔗 #65 
</br></br>

### 2️⃣작업 내용

✒️ 주간/월간 방문 건수 및 현재 방문 건수 비교
✒️ 일반진료/예방접종 건수 통계
✒️ 강아지/고양이/기타 동물별 진료 건수


</br></br>


### 3️⃣테스트
- [x] 로컬에서 테스트 완료 🧪🫧


✒️h2에 임시 데이터 삽입(펫, 진료 기록)
✒️swagger를 통해 확인

</br></br>
### 4️⃣이슈 넘버 기술
Closes #65 


