### PR TITLE
[FEAT] 예방접종 알림 기능 구현

### DIFF
--- a/backend/src/main/java/com/petner/anidoc/domain/notice/entity/Notice.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/notice/entity/Notice.java
@@ -32,5 +32,4 @@ public class Notice extends BaseEntity {
         this.title = noticeRequestDto.getTitle();
         this.content = noticeRequestDto.getContent();
     }
-
 }

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/config/SchedulerConfig.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/config/SchedulerConfig.java
@@ -1,0 +1,39 @@
+package com.petner.anidoc.domain.user.notification.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "scheduler.enabled", matchIfMissing = true)
+@Slf4j
+public class SchedulerConfig implements SchedulingConfigurer {
+
+    /**
+     * 스케줄링 설정을 위한 config 클래스
+     */
+
+    //에러 핸들러
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setScheduler(taskScheduler());
+    }
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("vaccination-scheduler-");
+        scheduler.setErrorHandler(t -> log.error("스케줄러 실행 중 오류: ", t));
+        scheduler.initialize();
+        return scheduler;
+    }
+
+
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.petner.anidoc.domain.user.notification.controller;
 import com.petner.anidoc.domain.user.notification.dto.NotificationDto;
 import com.petner.anidoc.domain.user.notification.entity.Notification;
 import com.petner.anidoc.domain.user.notification.service.NotificationService;
+import com.petner.anidoc.domain.user.pet.repository.PetRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "알림", description = "notification 관련 API")
 public class NotificationController {
     private final NotificationService notificationService;
+    private final PetRepository petRepository;
 
     //알림 전체 목록
     @Operation(summary = "알림 목록 조회", description = "알림 내역을 확인합니다.")

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/PetInfoDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/PetInfoDto.java
@@ -1,0 +1,37 @@
+package com.petner.anidoc.domain.user.notification.dto;
+
+import com.petner.anidoc.domain.user.pet.entity.Pet;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PetInfoDto {
+    private Long petId;
+    private Long ownerId;
+    private String name;
+    private String species;
+    private LocalDate birth;
+    private LocalDate lastDiroDate;
+    private boolean isDeceased;
+
+    public static PetInfoDto from(Pet pet){
+        return PetInfoDto.builder()
+                .petId(pet.getId())
+                .ownerId(pet.getOwner().getId())
+                .name(pet.getName())
+                .species(pet.getSpecies())
+                .birth(pet.getBirth())
+                .lastDiroDate(pet.getLastDiroDate())
+                .isDeceased(pet.isDeceased())
+                .build();
+
+    }
+
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/VaccinationNotificationDto.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/dto/VaccinationNotificationDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,5 +18,12 @@ public class VaccinationNotificationDto {
     private String vaccineName;
     private String nextDueDate;
     private String vaccinationDate;
+
+    private String petType;
+    private Integer round;
+    private String scheduleWeeks;
+    private String type;
+    private Boolean isRead;
+    private LocalDateTime createdAt;
 
 }

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/scheduler/VaccinationScheduler.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/scheduler/VaccinationScheduler.java
@@ -1,0 +1,45 @@
+package com.petner.anidoc.domain.user.notification.scheduler;
+
+import com.petner.anidoc.domain.user.notification.dto.PetInfoDto;
+import com.petner.anidoc.domain.user.notification.service.NotificationService;
+import com.petner.anidoc.domain.user.pet.entity.Pet;
+import com.petner.anidoc.domain.user.pet.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "scheduler.enabled", havingValue = "true", matchIfMissing = true)
+public class VaccinationScheduler {
+
+    private final NotificationService notificationService;
+    private final PetRepository petRepository;
+
+    /**
+     * 매일 오전 10시에 알림 체크
+     * cron = "초 분 시 일 월 요일"
+     */
+    @Scheduled(cron = "0 0 10 * * *")
+    public void checkVaccinationReminders(){
+        log.info("예방접종 알림 스케줄러");
+
+        List<Pet> alivePets = petRepository.findByIsDeceasedFalse();
+
+        int processedCount = 0;
+
+        for(Pet pet : alivePets){
+            PetInfoDto petDto = PetInfoDto.from(pet);
+            notificationService.sendVaccinationReminder(petDto);
+            processedCount++;
+        }
+
+        log.info("예방접종 알림 스케줄러 완료 {}건", processedCount);
+
+    }
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/service/NotificationService.java
@@ -1,8 +1,12 @@
 package com.petner.anidoc.domain.user.notification.service;
 
+import com.petner.anidoc.domain.user.notification.dto.PetInfoDto;
+import com.petner.anidoc.domain.user.notification.dto.VaccinationNotificationDto;
 import com.petner.anidoc.domain.user.notification.entity.Notification;
 import com.petner.anidoc.domain.user.notification.entity.NotificationType;
 import com.petner.anidoc.domain.user.notification.repository.NotificationRepository;
+import com.petner.anidoc.domain.user.notification.util.VaccinationNotificationHelper;
+import com.petner.anidoc.domain.user.notification.util.VaccinationScheduleManager;
 import com.petner.anidoc.domain.user.user.entity.User;
 import com.petner.anidoc.domain.user.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -20,6 +24,7 @@ public class NotificationService {
     private final SseEmitters sseEmitters;
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final VaccinationNotificationHelper vaccinationHelper;
 
     //특정 사용자에게 알림 저장 및 전송
     @Transactional
@@ -89,4 +94,28 @@ public class NotificationService {
 
     }
 
+    /**
+     * 예방접종 알림
+     */
+
+    @Transactional
+    public void sendVaccinationReminder(PetInfoDto petDto){
+        // 예방접종 체크 및 발송
+        if (vaccinationHelper.shouldSendVaccination(petDto)) {
+            VaccinationNotificationDto dto =
+                    vaccinationHelper.createVaccinationDto(petDto);
+            String content = vaccinationHelper.createVaccinationMessage(petDto);
+
+            if (dto != null && content != null) {
+                notifyUser(petDto.getOwnerId(), NotificationType.VACCINATION, content, dto);
+            }
+        }
+
+        // 심장사상충 체크 및 발송
+        if(vaccinationHelper.shouldSendDiro(petDto)){
+            String content = vaccinationHelper.createDiroMessage(petDto);
+            notifyUser(petDto.getOwnerId(), NotificationType.VACCINATION, content, null);
+
+        }
+    }
 }

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/VaccinationNotificationHelper.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/VaccinationNotificationHelper.java
@@ -1,0 +1,147 @@
+package com.petner.anidoc.domain.user.notification.util;
+
+import com.petner.anidoc.domain.user.notification.dto.PetInfoDto;
+import com.petner.anidoc.domain.user.notification.dto.VaccinationNotificationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@RequiredArgsConstructor
+public class VaccinationNotificationHelper {
+    private final VaccinationScheduleManager scheduleManager;
+
+    public boolean shouldSendVaccination(PetInfoDto petDto) {
+        //사망한 반려동물 제외
+        if (petDto.isDeceased()) return false;
+
+        //강아지, 고양이 아니면 제외
+        if (!scheduleManager.isVaccinationDue(petDto.getSpecies(), 0)) {
+            return false;
+        }
+
+        //접종 시기 확인
+        int currentWeek = calculateWeeks(petDto.getBirth());
+        VaccinationSchedule nextVaccination = scheduleManager.getNextVaccination(petDto.getSpecies(), currentWeek);
+
+        if(nextVaccination == null) return false;
+
+        // 접종 시작 5일 전
+        LocalDate vaccinationStartDate = petDto.getBirth().plusWeeks(nextVaccination.getStartWeek());
+        LocalDate reminderDate = vaccinationStartDate.minusDays(5);
+        LocalDate now = LocalDate.now();
+
+        return now.equals(reminderDate) || now.isAfter(reminderDate);
+
+    }
+
+    //알림 DTO
+    public VaccinationNotificationDto createVaccinationDto(PetInfoDto petDto){
+        int currentWeek = calculateWeeks(petDto.getBirth());
+        VaccinationSchedule schedule = scheduleManager.getNextVaccination(petDto.getSpecies(), currentWeek);
+
+        if(schedule == null) return null;
+
+        return VaccinationNotificationDto.builder()
+                .petId(petDto.getPetId())
+                .petName(petDto.getName())
+                .vaccineName(schedule.getVaccineTypes())
+                .nextDueDate(calculateNextDueDate(petDto.getBirth(), schedule))
+                .petType(determinePetType(petDto.getSpecies()))
+                .round(schedule.getRound())
+                .scheduleWeeks(String.format("생후 %d ~ %d주", schedule.getStartWeek(), schedule.getEndWeek()))
+                .type("VACCINATION")
+                .isRead(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    // 예방접종 알림 메시지
+    public String createVaccinationMessage(PetInfoDto petDto){
+        int currentWeek = calculateWeeks(petDto.getBirth());
+        VaccinationSchedule schedule = scheduleManager.getNextVaccination(petDto.getSpecies(), currentWeek);
+
+        if(schedule == null) return null;
+
+        //접종기간 계산
+        LocalDate start = petDto.getBirth().plusWeeks(schedule.getStartWeek());
+        LocalDate end = petDto.getBirth().plusWeeks(schedule.getEndWeek());
+
+        return String.format("5일 후 %s의 %d차 접종 기간이 시작됩니다. %s (%s ~ %s)", petDto.getName(), schedule.getRound(), schedule.getVaccineTypes()
+        , start.toString(), end.toString());
+    }
+
+    /**
+    심장사상충 알림
+    마지막 투여일로부터 30일, 값이 없으면 매달 15일
+    알림은 해당일 3일전에
+    */
+    //알림 확인
+    public boolean shouldSendDiro(PetInfoDto petDto){
+        LocalDate now = LocalDate.now();
+        LocalDate lastDiro = petDto.getLastDiroDate();
+
+        //마지막 투여일 30일 후 3일 전
+        if(lastDiro != null) {
+            LocalDate nextDueDate = lastDiro.plusDays(30);
+            LocalDate reminderDate = nextDueDate.minusDays(3); // 27일 후
+            return now.equals(reminderDate) || now.isAfter(reminderDate);
+        }
+
+        //투여일 없는 경우 매월 12일(15일의 3일전)
+        return now.getDayOfMonth() == 12;
+    }
+
+    //심장사상충 알림메시지
+    public String createDiroMessage(PetInfoDto petDto){
+        LocalDate lastDiro = petDto.getLastDiroDate();
+
+        if(lastDiro != null){
+            LocalDate nextDueDate = lastDiro.plusDays(27);
+            return String.format("3일 후 %s의 심장사상충 예방약 투여 예정일 입니다.(%s)"
+                    ,petDto.getName(), nextDueDate.toString());
+        }else {
+            return String.format("3일 후 %s의 심장사상충 예방약 투여 예정일 입니다."
+            ,petDto.getName());
+        }
+    }
+
+
+
+    /*계산 메서드 */
+
+    // 출생일 기준 주차 계산
+    private int calculateWeeks(LocalDate birthDate){
+        if(birthDate == null) return 0;
+
+        return (int) ChronoUnit.WEEKS.between(birthDate, LocalDate.now());
+    }
+
+    // 반려동물 타입 확인
+    private String determinePetType(String species){
+        // 이미 1차적으로 기타 반려동물 제외
+        if(species == null) return "강아지";
+
+        String type = species.toLowerCase();
+
+        if(type.contains("고양이")){
+            return "고양이";
+        }
+        if(type.contains("강아지") || type.contains("개")){
+            return "강아지";
+        }
+        return "강아지";
+    }
+
+    // 다음 접종 예정일
+    private String calculateNextDueDate(LocalDate birthDate, VaccinationSchedule schedule){
+        if(birthDate == null) return null;
+        LocalDate dueDate = birthDate.plusWeeks(schedule.getStartWeek());
+        return dueDate.toString();
+
+    }
+
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/VaccinationSchedule.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/VaccinationSchedule.java
@@ -1,0 +1,17 @@
+package com.petner.anidoc.domain.user.notification.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VaccinationSchedule {
+    private int round;
+    private int startWeek;
+    private int endWeek;
+    private String vaccineTypes;
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/VaccinationScheduleManager.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/notification/util/VaccinationScheduleManager.java
@@ -1,0 +1,76 @@
+package com.petner.anidoc.domain.user.notification.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class VaccinationScheduleManager {
+
+    //강아지 예방접종 주기
+    private static final List<VaccinationSchedule> dogSchedule = Arrays.asList(
+            VaccinationSchedule.builder().round(1).startWeek(6).endWeek(8).vaccineTypes("종합백신, 코로나장염")
+              .build(),
+            VaccinationSchedule.builder().round(2).startWeek(8).endWeek(10).vaccineTypes("종합백신, 코로나장염")
+                    .build(),
+            VaccinationSchedule.builder().round(3).startWeek(10).endWeek(12).vaccineTypes("종합백신, 켄넬코프")
+                    .build(),
+            VaccinationSchedule.builder().round(4).startWeek(12).endWeek(14).vaccineTypes("종합백신, 켄넬코프")
+                    .build(),
+            VaccinationSchedule.builder().round(5).startWeek(14).endWeek(16).vaccineTypes("종합백신, 인플루엔자")
+                    .build(),
+            VaccinationSchedule.builder().round(6).startWeek(16).endWeek(18).vaccineTypes("광견병, 인플루엔자, 항체가검사")
+                    .build()
+    );
+
+    //고양이 예방접종 주기
+    private static final List<VaccinationSchedule> catSchedule = Arrays.asList(
+            VaccinationSchedule.builder().round(1).startWeek(6).endWeek(8).vaccineTypes("종합백신")
+                    .build(),
+            VaccinationSchedule.builder().round(2).startWeek(8).endWeek(10).vaccineTypes("종합백신")
+                    .build(),
+            VaccinationSchedule.builder().round(3).startWeek(10).endWeek(12).vaccineTypes("종합백신, 광견병")
+                    .build(),
+            VaccinationSchedule.builder().round(4).startWeek(12).endWeek(14).vaccineTypes("전염성 복막염")
+                    .build(),
+            VaccinationSchedule.builder().round(5).startWeek(14).endWeek(16).vaccineTypes("항체가검사")
+                    .build()
+    );
+
+    // 반려동물 타입 및 접종 스케줄(주차) 조회
+    public VaccinationSchedule getNextVaccination(String petType, int currentWeek){
+        List<VaccinationSchedule> schedule = getScheduleByPetType(petType);
+        if(schedule == null) return null;
+
+        return schedule.stream()
+                .filter(v -> currentWeek >= v.getStartWeek() && currentWeek <= v.getEndWeek())
+                .findFirst()
+                .orElse(null);
+    }
+
+    //대상 확인
+    public boolean isVaccinationDue(String petType, int currentWeek){
+        return getScheduleByPetType(petType) != null;
+    }
+
+    //반려동물 타입에 따른 스케줄 반환
+    private List<VaccinationSchedule> getScheduleByPetType(String petType){
+       if(petType == null) return null;
+
+       String type = petType.toLowerCase();
+
+       //강아지 확인
+        if(type.contains("강아지") || type.contains("개")){
+            return dogSchedule;
+        }
+
+        //고양이 확인
+        if (type.contains("고양이")){
+            return catSchedule;
+        }
+        return null;
+    }
+
+
+}

--- a/backend/src/main/java/com/petner/anidoc/domain/user/pet/repository/PetRepository.java
+++ b/backend/src/main/java/com/petner/anidoc/domain/user/pet/repository/PetRepository.java
@@ -8,4 +8,8 @@ import java.util.List;
 @Repository
 public interface PetRepository extends JpaRepository<Pet, Long> {
     List<Pet> findByOwnerId(Long ownerId);
+
+    //살아있는 반려동물 조회
+    List<Pet> findByIsDeceasedFalse();
+
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -82,3 +82,6 @@ aws:
     secret-key: ${AWS_SECRET_ACCESS_KEY}
     region: ${AWS_REGION}
     bucket: ${S3_BUCKET_NAME}
+
+scheduler:
+  enabled: true


### PR DESCRIPTION

# 🧠 Feature PR


### 1️⃣관련 이슈 

🔗 #82 
</br></br>

### 2️⃣작업 내용

✒️ 예방접종 알림 스케줄러 구현
✒️ 매일 오전 10시 자동 발송
✒️ 심장사상충은 3일 전, 예방접종은 5일 전으로 설정

</br></br>


### 3️⃣테스트
*[ ]안에 x를 넣으시면 체크가 됩니다.*
- [x] 로컬에서 테스트 완료 🧪🫧

</br>

✒️ 스케줄러 시간 지정 후 발송
✒️ log 및 h2 확인

</br></br>
### 4️⃣이슈 넘버 기술
Closes #82 


