### PR TITLE
[FIX] 비로그인 상태에서 소셜 로그인 API 호출 수정

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -17,9 +17,14 @@ export default function LoginPage() {
   // 소셜 로그인 체크
   useEffect(() => {
     const checkLoginStatus = async () => {
-      // 이미 UserContext에서 로그인 상태가 true라면 체크하지 않고 리다이렉트
+      // 이미 로그인된 상태라면 메인 페이지로 리다이렉트
       if (isLoggedIn) {
         router.push("/");
+        return;
+      }
+
+      // URL에 isSocialLogin이 있는 경우에만 체크
+      if (!window.location.search.includes("isSocialLogin")) {
         return;
       }
 
@@ -45,7 +50,7 @@ export default function LoginPage() {
     };
 
     checkLoginStatus();
-  }, [isLoggedIn, login, router]); // 의존성 배열에 isLoggedIn 추가
+  }, [isLoggedIn, login, router]);
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
@@ -88,13 +93,13 @@ export default function LoginPage() {
 
   const handleKakaoLogin = () => {
     // 메인 페이지로 리다이렉트
-    const redirectUrl = window.location.origin;
+    const redirectUrl = `${window.location.origin}/login?isSocialLogin=true`;
     window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/oauth2/authorization/kakao?redirectUrl=${redirectUrl}`;
   };
 
   const handleNaverLogin = () => {
     // 메인 페이지로 리다이렉트
-    const redirectUrl = window.location.origin;
+    const redirectUrl = `${window.location.origin}/login?isSocialLogin=true`;
     window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/oauth2/authorization/naver?redirectUrl=${redirectUrl}`;
   };
 

--- a/frontend/src/components/ClientLayout.tsx
+++ b/frontend/src/components/ClientLayout.tsx
@@ -13,7 +13,10 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
   const pathname = usePathname();
 
   // 로그인 페이지 여부 확인
-  const isAuthPage = pathname === "/login" || pathname.includes("/register");
+  const isAuthPage =
+    pathname === "/login" ||
+    pathname.includes("/register") ||
+    pathname.includes("/auth-register");
 
   // 로그인 페이지는 Sidebar와 Header 표시하지 않음
   if (isAuthPage) {


### PR DESCRIPTION

# 🐞 Bugfix PR

### 1️⃣관련 이슈

🔗#89 
</br></br>

### 2️⃣버그 설명


✒️사용자가 일반적으로 /login 페이지에 접속 시, useEffect가 실행되면서 무조건 /api/social/me API를 호출함
✒️하지만 일반 접속자는 소셜 로그인을 한 적이 없으므로 인증되지 않은 상태임.
✒️서버에서 401 Unauthorized 또는 다른 에러가 발생하고, 콘솔에 "로그인 상태 확인 실패" 에러 출력되는 에러. 

</br></br>

### 3️⃣수정 내역
✒️?isSocialLogin=true 파라미터가 있을 때만 소셜 로그인 상태 체크
✒️ 즉, 소셜 로그인 후 리다이렉트된 경우에만 API 호출함.


✨추가 : 소셜로그인 시 Role 선택창이 중앙정렬 되어있지 않은 오류 수정 
</br></br>
### 4️⃣이슈 넘버 기술
Closes #89 
